### PR TITLE
fix: do not merge variables with main class if namespace is provided

### DIFF
--- a/envier/env.py
+++ b/envier/env.py
@@ -292,6 +292,8 @@ class Env(object):
 
             setattr(cls, namespace, env_spec)
 
+            return None
+
         # Pick only the attributes that define variables.
         to_include = {
             k: v

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -243,6 +243,10 @@ def test_env_include_namespace(monkeypatch):
 
     assert GlobalConfig().service.host == "example.com"
 
+    # Check that we are not including configuration elsewhere
+    with pytest.raises(AttributeError):
+        GlobalConfig().host
+
 
 @pytest.mark.parametrize(
     "map,expected",


### PR DESCRIPTION
This change fixes an issue with the include method merging variables with the main class even when a namespace is provided.