### PR TITLE
ci: add smoke test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,4 +67,5 @@ jobs:
       - name: Run tests
         run: |
           python3.9 -m pip install riot
-          riot -v run --python=${{ matrix.python-version }} test
+          riot -v run --python=${{ matrix.python-version }} smoke-test
+          riot -v run --python=${{ matrix.python-version }} tests

--- a/riotfile.py
+++ b/riotfile.py
@@ -21,6 +21,11 @@ venv = Venv(
             command="pytest {cmdargs}",
         ),
         Venv(
+            name="smoke-test",
+            command="python -c 'import envier'",
+            pys=SUPPORTED_PYTHON_VERSIONS,
+        ),
+        Venv(
             name="black",
             pkgs={"black": latest},
             command="black {cmdargs}",


### PR DESCRIPTION
When installing additional packages into a virtual environment, like pytest, the site-packages location might get "polluted" and it is easy to miss dependency declarations in the setup script. This change adds a smoke test to detect this sort of issues.