### PR TITLE
fix: handle empty prefix in subconfig correctly

### DIFF
--- a/envier/env.py
+++ b/envier/env.py
@@ -207,7 +207,7 @@ class Env(object):
         ) + _normalized(
             self.__prefix__
         )  # type: str
-        if self._full_prefix:
+        if self._full_prefix and not self._full_prefix.endswith("_"):
             self._full_prefix += "_"
 
         self.spec = self.__class__

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -140,11 +140,14 @@ def test_env_prefix(monkeypatch):
     assert Config().foo == 24
 
 
-def test_env_nested_config(monkeypatch):
-    monkeypatch.setenv("MYAPP_SERVICE_PORT", "8080")
+@pytest.mark.parametrize(
+    "prefix,var", [("", "MYAPP_PORT"), ("service", "MYAPP_SERVICE_PORT")]
+)
+def test_env_nested_config(monkeypatch, prefix, var):
+    monkeypatch.setenv(var, "8080")
 
     class ServiceConfig(Env):
-        __prefix__ = "service"
+        __prefix__ = prefix
 
         host = Env.var(str, "host", default="localhost")
         port = Env.var(int, "port", default=3000)


### PR DESCRIPTION
This change ensures that sub-configurations with an empty prefix don't end up looking for environment variables with a double underscore as separator.