### PR TITLE
ci(sphinx): update generated artifacts to latest release

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 import sys
 
 
-if sys.version_info >= (3, 6):
-    # DEV: We are not running the Sphinx extension tests on Python < 3.6 due to
+if sys.version_info >= (3, 7):
+    # DEV: We are not running the Sphinx extension tests on Python < 3.7 due to
     # lack of support.
     import pytest
     from sphinx.testing.path import path

--- a/tests/sphinx/test-root/_build/index.html
+++ b/tests/sphinx/test-root/_build/index.html
@@ -4,7 +4,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.18.1: http://docutils.sourceforge.net/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.19: https://docutils.sourceforge.io/" />
 
     <title>&lt;no title&gt; &#8212; test-root  documentation</title>
     <link rel="stylesheet" type="text/css" href="_static/pygments.css" />
@@ -34,10 +34,10 @@
             
   <table class="docutils align-default">
 <colgroup>
-<col style="width: 33%" />
-<col style="width: 11%" />
-<col style="width: 11%" />
-<col style="width: 44%" />
+<col style="width: 33.3%" />
+<col style="width: 11.1%" />
+<col style="width: 11.1%" />
+<col style="width: 44.4%" />
 </colgroup>
 <thead>
 <tr class="row-odd"><th class="head"><p>Variable Name</p></th>
@@ -127,7 +127,7 @@
       &copy;2022, Datadog.
       
       |
-      Powered by <a href="http://sphinx-doc.org/">Sphinx 5.0.2</a>
+      Powered by <a href="http://sphinx-doc.org/">Sphinx 5.1.1</a>
       &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster 0.7.12</a>
       
       |

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -4,7 +4,7 @@ from sys import version_info as PY
 import pytest
 
 
-@pytest.mark.skipif(PY < (3, 6), reason="requires Python 3.6+")
+@pytest.mark.skipif(PY < (3, 7), reason="requires Python 3.7+")
 def test(app, rootdir):
     app.build()
 


### PR DESCRIPTION
The latest release of Sphinx produces a slightly different HTML. We
replace the generated source to make the test pass again.