### PR TITLE
feat: add config sources

### DIFF
--- a/envier/env.py
+++ b/envier/env.py
@@ -199,7 +199,7 @@ class DerivedVariable(Generic[T]):
         return value
 
 
-ConfigSourceType = Literal["default", "environment", "programmatic"]
+ConfigSourceType = Literal["default", "environment", "code"]
 
 
 class _EnvSource(object):
@@ -272,9 +272,9 @@ class Env(object):
         self._items = defaultdict(
             lambda: _EnvSource(
                 [
-                    "programmatic",
                     "environment",
                     "default",
+                    "code",
                 ]
             )
         )  # type: DefaultDict[str, _EnvSource]
@@ -311,7 +311,7 @@ class Env(object):
 
     def __setattr__(self, name, value):
         if name != "_items":
-            self._items[name].set_source("programmatic", value)
+            self._items[name].set_source("code", value)
         super(Env, self).__setattr__(name, value)
 
     def set_attr_source_value(self, name, source, value):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,10 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests*"]),
     python_requires=">=2.7",
-    install_requires=["typing; python_version<'3.5'"],
+    install_requires=[
+        "typing; python_version<'3.5'",
+        "typing_extensions; python_version<'3.8'",
+    ],
     extras_require={"mypy": ["mypy"]},
     setup_requires=["setuptools_scm"],
     use_scm_version=True,

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -377,6 +377,6 @@ def test_env_multi_source(monkeypatch):
     # Test the programmatic source.
     cfg.foo = 2
     assert cfg.foo == 2
-    assert cfg.source_type("foo") == "programmatic"
-    cfg.set_attr_source_value("foo", "programmatic", 10)
+    assert cfg.source_type("foo") == "code"
+    cfg.set_attr_source_value("foo", "code", 10)
     assert cfg.foo == 10

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -344,3 +344,39 @@ def test_env_validator(monkeypatch, value, exc):
             Config()
     else:
         assert Config().foo == value
+
+
+def test_getitem():
+    class Config(Env):
+        foo = Env.var(int, "FOO", default=42)
+
+    assert Config()["foo"] == 42
+
+
+def test_env_multi_source(monkeypatch):
+    """Ensure multiple sources are supported."""
+
+    class Config(Env):
+        foo = Env.var(int, "FOO", default=0)
+
+    # Test the default source.
+    cfg = Config()
+    assert cfg.foo == 0
+    assert cfg.source_type("foo") == "default"
+    cfg.set_attr_source_value("foo", "default", 5)
+    assert cfg.foo == 5
+
+    # Test the environment source.
+    monkeypatch.setenv("FOO", "1")
+    cfg = Config()
+    assert cfg.foo == 1
+    assert cfg.source_type("foo") == "environment"
+    cfg.set_attr_source_value("foo", "environment", 6)
+    assert cfg.foo == 6
+
+    # Test the programmatic source.
+    cfg.foo = 2
+    assert cfg.foo == 2
+    assert cfg.source_type("foo") == "programmatic"
+    cfg.set_attr_source_value("foo", "programmatic", 10)
+    assert cfg.foo == 10


### PR DESCRIPTION
Add support for setting and storing configuration from additional sources. This enables a setting to have values coming from a default, environment or programmatic source.

The default priority of the sources is (lowest to highest):

1. Default
2. Environment
3. Programmatic