### PR TITLE
ci: fix and update dependencies

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_wheel:
     name: Build wheels
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,4 +46,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: docker run --rm -v $PWD:/work/envier -w /work/envier ghcr.io/kyle-verhoog/envier/test:a0e8d6f38400e8bf21fc0e30ccba4001a6885884 bash -c "git config --global --add safe.directory '*' && riot -v run smoke-test && riot -v run tests"
+      - run: |
+          docker run \
+            --rm \
+            -v $PWD:/work/envier \
+            -w /work/envier \
+            ghcr.io/kyle-verhoog/envier/test:a0e8d6f38400e8bf21fc0e30ccba4001a6885884 \
+            bash -c "riot -v run smoke-test && riot -v run tests"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
-      - name: Install project
-        run: pip install .
-      - name: Run command
+          python-version: '3.11'
+      - name: Check formatting
         run: |
-          pip3 install riot
+          python -m pip install riot==0.18.0
           riot -v run -s black -- --check .
   mypy:
     runs-on: ubuntu-latest
@@ -24,12 +22,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install project
         run: pip install .
       - name: Run command
         run: |
-          pip3 install riot
+          python -m pip install riot==0.18.0
           riot -v run -s mypy
   flake8:
     runs-on: ubuntu-latest
@@ -37,35 +35,15 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
-      - name: Install project
-        run: pip install .
+          python-version: '3.11'
       - name: Run command
         run: |
-          pip3 install riot
+          python -m pip install riot==0.18.0
           riot -v run -s flake8
   test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", pypy-3.7]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Setup Python 3 (for riot)
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
-      - name: Install project
-        run: |
-          pip install setuptools
-          pip install .
-      - name: Run tests
-        run: |
-          python3.9 -m pip install riot
-          riot -v run --python=${{ matrix.python-version }} smoke-test
-          riot -v run --python=${{ matrix.python-version }} tests
+          fetch-depth: 0
+      - run: docker run --rm -v $PWD:/work/envier -w /work/envier ghcr.io/kyle-verhoog/envier/test:a0e8d6f38400e8bf21fc0e30ccba4001a6885884 bash -c "git config --global --add safe.directory '*' && riot -v run smoke-test && riot -v run tests"

--- a/riotfile.py
+++ b/riotfile.py
@@ -11,8 +11,9 @@ venv = Venv(
             venvs=[
                 Venv(
                     pkgs={
-                        "mypy": latest,
-                        "sphinx": latest,
+                        "mypy": "==0.961",
+                        "sphinx": "==5.1.1",
+                        "alabaster": "==0.7.12",
                     },
                     pys=SUPPORTED_PYTHON_VERSIONS[2:],
                 ),

--- a/tests/test_sphinx.py
+++ b/tests/test_sphinx.py
@@ -1,4 +1,3 @@
-from filecmp import cmp
 from sys import version_info as PY
 
 import pytest
@@ -11,4 +10,10 @@ def test(app, rootdir):
     reference = rootdir / "test-root" / "_build" / "index.html"
     generated = app.outdir / "index.html"
 
-    assert cmp(reference, generated)
+    with open(reference) as f:
+        reference = f.read()
+
+    with open(generated) as f:
+        generated = f.read()
+
+    assert reference == generated


### PR DESCRIPTION
Support for Python versions 2.7 and 3.5 were dropped by the Github action. See https://github.com/actions/setup-python/issues/672 for more info.

To work around this we can test using our own image.