### PR TITLE
chore: change license to reference file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: MIT License",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "envier"
 dynamic = ["version"]
 description = "Python application configuration via the environment"
 readme = "README.md"
-license = "MIT"
+license = {file = "LICENSE"}
 requires-python = ">=3.7"
 authors = [
     { name = "Datadog", email = "dev@datadoghq.com" },


### PR DESCRIPTION
https://github.com/DataDog/envier/issues/33 

Currently the envier library is being published without a license in PYPI, I think that this fix should add the license properly: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license
![Screenshot 2024-01-22 at 12 37 06 PM](https://github.com/DataDog/envier/assets/32471391/f62cdf35-f7c0-4ca2-a681-5661f0bafa36)

I think we could alternatively do ``license = {text = "MIT License"}`` but I don't think it matters.
