### PR TITLE
refactor!: expose HelpInfo as a namedtuple

### DIFF
--- a/envier/__init__.py
+++ b/envier/__init__.py
@@ -1,5 +1,6 @@
 from envier.env import Env
+from envier.env import HelpInfo
 
 
 En = Env
-__all__ = ["En", "Env"]
+__all__ = ["En", "Env", "HelpInfo"]

--- a/envier/env.py
+++ b/envier/env.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import os
 import typing as t
 import warnings
@@ -17,7 +18,7 @@ K = t.TypeVar("K")
 V = t.TypeVar("V")
 
 MapType = t.Union[t.Callable[[str], V], t.Callable[[str, str], t.Tuple[K, V]]]
-HelpInfo = t.Tuple[str, str, str, str]
+HelpInfo = namedtuple("HelpInfo", ("name", "type", "default", "help"))
 
 
 def _normalized(name: str) -> str:
@@ -432,7 +433,7 @@ class Env(object):
                     help_type = v.help_type
                 else:
                     try:
-                        help_type = "``%s``" % v.type.__name__  # type: ignore[attr-defined]
+                        help_type = v.type.__name__  # type: ignore[attr-defined]
                     except AttributeError:
                         # typing.t.Union[<type>, NoneType]
                         help_type = v.type.__args__[0].__name__  # type: ignore[attr-defined]
@@ -440,8 +441,8 @@ class Env(object):
                 private_prefix = "_" if v.private else ""
 
                 entries.append(
-                    (
-                        f"``{private_prefix}{full_prefix}{_normalized(v.name)}``",
+                    HelpInfo(
+                        f"{private_prefix}{full_prefix}{_normalized(v.name)}",
                         help_type,  # type: ignore[attr-defined]
                         (
                             v.help_default

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -4,6 +4,7 @@ import pytest
 
 from envier import En
 from envier import Env
+from envier import HelpInfo
 
 
 def test_env_default():
@@ -377,8 +378,8 @@ def test_env_private(monkeypatch):
     assert config.private == 24
     assert config.public == 25
 
-    assert Config.help_info() == [("``PUBLIC_FOO``", "``int``", "42", "")]
+    assert Config.help_info() == [HelpInfo("PUBLIC_FOO", "int", "42", "")]
     assert set(Config.help_info(include_private=True)) == {
-        ("``_PRIVATE_FOO``", "``int``", "42", ""),
-        ("``PUBLIC_FOO``", "``int``", "42", ""),
+        ("_PRIVATE_FOO", "int", "42", ""),
+        ("PUBLIC_FOO", "int", "42", ""),
     }

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,4 +1,5 @@
 from envier import Env
+from envier import HelpInfo
 
 
 class GlobalConfig(Env):
@@ -46,15 +47,15 @@ def test_help_info(monkeypatch):
     monkeypatch.setenv("MYAPP_NO_DEFAULT", "1")
 
     assert GlobalConfig.help_info() == [
-        ("``MYAPP_DEBUG``", "Boolean", "False", "Whether to enable debug logging."),
-        (
-            "``MYAPP_NO_DEFAULT``",
+        HelpInfo("MYAPP_DEBUG", "Boolean", "False", "Whether to enable debug logging."),
+        HelpInfo(
+            "MYAPP_NO_DEFAULT",
             "Boolean",
             "",
             "A variable with no default value, which makes it mandatory.",
         ),
-        (
-            "``MYAPP_URL``",
+        HelpInfo(
+            "MYAPP_URL",
             "String",
             "http://localhost:5000",
             "The URL of the application.",
@@ -66,19 +67,19 @@ def test_help_info_recursive(monkeypatch):
     monkeypatch.setenv("MYAPP_NO_DEFAULT", "1")
 
     assert GlobalConfig.help_info(recursive=True) == [
-        ("``MYAPP_DEBUG``", "Boolean", "False", "Whether to enable debug logging."),
-        (
-            "``MYAPP_NO_DEFAULT``",
+        HelpInfo("MYAPP_DEBUG", "Boolean", "False", "Whether to enable debug logging."),
+        HelpInfo(
+            "MYAPP_NO_DEFAULT",
             "Boolean",
             "",
             "A variable with no default value, which makes it mandatory.",
         ),
-        (
-            "``MYAPP_URL``",
+        HelpInfo(
+            "MYAPP_URL",
             "String",
             "http://localhost:5000",
             "The URL of the application.",
         ),
-        ("``MYAPP_SERVICE_HOST``", "``str``", "localhost", "The host of the service."),
-        ("``MYAPP_SERVICE_PORT``", "``int``", "3000", "The port of the service."),
+        HelpInfo("MYAPP_SERVICE_HOST", "str", "localhost", "The host of the service."),
+        HelpInfo("MYAPP_SERVICE_PORT", "int", "3000", "The port of the service."),
     ]


### PR DESCRIPTION
We refactor the HelpInfo type to be a namedtuple and be part of the public API for better consumption of the information. We also drop the assumption that the variable name would be formatted in a RST document and remove the double backtick wrapping from the generated help info data.