### PR TITLE
fix: regression in include with namespace no overwrite

### DIFF
--- a/envier/env.py
+++ b/envier/env.py
@@ -413,10 +413,6 @@ class Env(metaclass=EnvMeta):
             or isinstance(v, type)
             and issubclass(v, Env)
         }
-        if not overwrite:
-            overlap = set(cls.__dict__.keys()) & set(to_include.keys())
-            if overlap:
-                raise ValueError("Configuration clashes detected: {}".format(overlap))
 
         own_prefix = _normalized(getattr(cls, "__prefix__", ""))
 
@@ -433,6 +429,11 @@ class Env(metaclass=EnvMeta):
                             v._full_name = f"{own_prefix}_{v._full_name}"
 
             return None
+
+        if not overwrite:
+            overlap = set(cls.__dict__.keys()) & set(to_include.keys())
+            if overlap:
+                raise ValueError("Configuration clashes detected: {}".format(overlap))
 
         other_prefix = getattr(env_spec, "__prefix__", "")
         for k, v in to_include.items():

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -250,12 +250,14 @@ def test_env_include_namespace(monkeypatch):
         __prefix__ = "myapp"
 
         debug_mode = Env.var(bool, "debug", default=False)
+        enable = Env.var(bool, "enable", default=True)
 
     class ServiceConfig(Env):
         __prefix__ = "service"
 
         host = Env.var(str, "host", default="localhost")
         port = Env.var(int, "port", default=3000)
+        enable = Env.var(bool, "enable", default=False)
 
     GlobalConfig.include(ServiceConfig, namespace="service")
     with pytest.raises(ValueError):


### PR DESCRIPTION
We fix a regression with the include method when using a namespace for sub-configuration with like-named items.